### PR TITLE
Bug: OutOfMemory crashes with custom download directories

### DIFF
--- a/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/common/SafFolderHelper.kt
+++ b/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/common/SafFolderHelper.kt
@@ -3,6 +3,7 @@ package luci.sixsixsix.powerampache2.data.common
 import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
+import java.io.InputStream
 
 class SafFolderHelper(private val context: Context) {
     fun getOrCreatePath(rootUri: Uri, fullPath: String): DocumentFile {
@@ -31,7 +32,8 @@ class SafFolderHelper(private val context: Context) {
         folder: DocumentFile,
         fileName: String,
         mimeType: String?,
-        bytes: ByteArray
+        inputStream: InputStream,
+        bufferSize: Int
     ): Uri {
         val existing = folder.findFile(fileName)
         existing?.delete() // optional: replace existing file
@@ -41,8 +43,20 @@ class SafFolderHelper(private val context: Context) {
             fileName)
             ?: error("Cannot create file: $fileName")
 
-        context.contentResolver.openOutputStream(file.uri)?.use {
-            it.write(bytes)
+        try {
+            context.contentResolver.openOutputStream(file.uri)?.use { outputStream ->
+                val buffer = ByteArray(bufferSize)
+                var read: Int
+                while (inputStream.read(buffer).also { read = it } != -1) {
+                    outputStream.write(buffer, 0, read)
+                }
+
+                outputStream.flush()
+            }
+        } catch (e: Exception) {
+            throw e
+        } finally {
+            inputStream.close()
         }
 
         return file.uri
@@ -54,8 +68,8 @@ class SafFolderHelper(private val context: Context) {
         return existing?.delete() ?: false
     }
 
-    suspend fun writeFile(rootUri: Uri, fullPath: String, fileName: String, mimeType: String?, bytes: ByteArray): Uri {
+    suspend fun writeFile(rootUri: Uri, fullPath: String, fileName: String, mimeType: String?, inputStream: InputStream, bufferSize: Int): Uri {
         val folder = getOrCreatePath(rootUri, fullPath)
-        return writeFile(folder, fileName, mimeType, bytes)
+        return writeFile(folder, fileName, mimeType, inputStream, bufferSize)
     }
 }

--- a/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/common/SafFolderHelper.kt
+++ b/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/common/SafFolderHelper.kt
@@ -3,6 +3,7 @@ package luci.sixsixsix.powerampache2.data.common
 import android.content.Context
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
+import luci.sixsixsix.powerampache2.domain.errors.FileWriteException
 import java.io.InputStream
 
 class SafFolderHelper(private val context: Context) {
@@ -28,6 +29,7 @@ class SafFolderHelper(private val context: Context) {
         return getOrCreatePath(rootUri, fullPath).uri
     }
 
+    @Throws(Exception::class)
     fun writeFile(
         folder: DocumentFile,
         fileName: String,
@@ -54,7 +56,7 @@ class SafFolderHelper(private val context: Context) {
                 outputStream.flush()
             }
         } catch (e: Exception) {
-            throw e
+            throw FileWriteException("error writing file: ${e.localizedMessage}")
         } finally {
             inputStream.close()
         }

--- a/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/StorageManagerImpl.kt
+++ b/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/StorageManagerImpl.kt
@@ -63,7 +63,8 @@ class StorageManagerImpl @Inject constructor(
                     fullPath = getDirPathFromSong(song),
                     fileName = getFileNameFromSong(song),
                     mimeType = song.mime,
-                    bytes = inputStream.readBytes()
+                    inputStream = inputStream,
+                    bufferSize = BUFFER_SIZE
                 ).toString()
             } else {
                 val absoluteDirPath = getAbsolutePathDir(song)

--- a/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/StorageManagerImpl.kt
+++ b/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/StorageManagerImpl.kt
@@ -68,7 +68,7 @@ class StorageManagerImpl @Inject constructor(
                 ).toString()
             } else {
                 val absoluteDirPath = getAbsolutePathDir(song)
-                val directory = File(absoluteDirPath)
+                val directory = File(absoluteDirPath!!) // TODO fix double-bang
                 if (!directory.exists()) {
                     directory.mkdirs()
                 }
@@ -96,7 +96,7 @@ class StorageManagerImpl @Inject constructor(
     override suspend fun saveImage(song: Song, inputStream: InputStream) =
         withContext(Dispatchers.IO) {
             val absoluteDirPath = getAbsolutePathDir(song)
-            val directory = File(absoluteDirPath)
+            val directory = File(absoluteDirPath!!)
             if (!directory.exists()) {
                 directory.mkdirs()
             }

--- a/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/StorageManagerImpl.kt
+++ b/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/StorageManagerImpl.kt
@@ -31,6 +31,7 @@ import luci.sixsixsix.mrlog.L
 import luci.sixsixsix.powerampache2.data.common.SafFolderHelper
 import luci.sixsixsix.powerampache2.domain.MusicRepository
 import luci.sixsixsix.powerampache2.domain.common.Constants
+import luci.sixsixsix.powerampache2.domain.errors.FileWriteException
 import luci.sixsixsix.powerampache2.domain.models.Song
 import luci.sixsixsix.powerampache2.domain.utils.SharedPreferencesManager
 import luci.sixsixsix.powerampache2.domain.utils.StorageManager
@@ -54,26 +55,27 @@ class StorageManagerImpl @Inject constructor(
     @Throws(Exception::class)
     override suspend fun saveSong(song: Song, inputStream: InputStream) =
         withContext(Dispatchers.IO) {
-            val safFolderHelper = SafFolderHelper(context)
-            val rootUri = sharedPreferencesManager.customDownloadRootUri
-            return@withContext if (Constants.config.enableExternalDirDownloads
-                && isStorageCustom(rootUri)) {
-                safFolderHelper.writeFile(
-                    rootUri = rootUri!!,
-                    fullPath = getDirPathFromSong(song),
-                    fileName = getFileNameFromSong(song),
-                    mimeType = song.mime,
-                    inputStream = inputStream,
-                    bufferSize = BUFFER_SIZE
-                ).toString()
-            } else {
-                val absoluteDirPath = getAbsolutePathDir(song)
-                val directory = File(absoluteDirPath!!) // TODO fix double-bang
-                if (!directory.exists()) {
-                    directory.mkdirs()
-                }
-                val absolutePath = getAbsolutePathFile(song)!! // TODO fix double-bang!!
-                try {
+            try {
+                val safFolderHelper = SafFolderHelper(context)
+                val rootUri = sharedPreferencesManager.customDownloadRootUri
+                return@withContext if (Constants.config.enableExternalDirDownloads
+                    && isStorageCustom(rootUri)) {
+                    safFolderHelper.writeFile(
+                        rootUri = rootUri!!,
+                        fullPath = getDirPathFromSong(song),
+                        fileName = getFileNameFromSong(song),
+                        mimeType = song.mime,
+                        inputStream = inputStream,
+                        bufferSize = BUFFER_SIZE
+                    ).toString()
+                } else {
+                    val absoluteDirPath = getAbsolutePathDir(song)
+                    val directory = File(absoluteDirPath!!) // TODO fix double-bang
+                    if (!directory.exists()) {
+                        directory.mkdirs()
+                    }
+
+                    val absolutePath = getAbsolutePathFile(song)!! // TODO fix double-bang!!
                     val fos = FileOutputStream(absolutePath)
                     fos.use { output ->
                         val buffer = ByteArray(BUFFER_SIZE)
@@ -83,12 +85,13 @@ class StorageManagerImpl @Inject constructor(
                         }
                         output.flush()
                     }
+
                     absolutePath
-                } catch (e: Exception) {
-                    throw e
-                } finally {
-                    inputStream.close()
                 }
+            } catch (e: Exception) {
+                throw FileWriteException("error writing file: ${e.localizedMessage}")
+            } finally {
+                inputStream.close()
             }
         }
 

--- a/domain/src/main/java/luci/sixsixsix/powerampache2/domain/errors/FileWriteException.kt
+++ b/domain/src/main/java/luci/sixsixsix/powerampache2/domain/errors/FileWriteException.kt
@@ -1,0 +1,5 @@
+package luci.sixsixsix.powerampache2.domain.errors
+
+import java.io.IOException
+
+class FileWriteException(infoData: String): IOException("FILE-WRITE-EXCEPTION: $infoData")


### PR DESCRIPTION
This fixes possible crashes with downloading big files when using custom download directories. The whole file was trying to be fitted in the heap, leading to out of memory crash.
This fix proposes reusing the logic for handling internal downloads.