### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "PowerAmpache2Theme"]
 	path = PowerAmpache2Theme
-	url = git@github.com:icefields/PowerAmpache2Theme.git
+	url = https://github.com/icefields/PowerAmpache2Theme


### PR DESCRIPTION
Fix the link to PowerAmpache2Theme submodule, for it to be accessible without SSH keys when cloning the repository