### PR TITLE
Make users with admin access eligible for editing any playlist

### DIFF
--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
@@ -41,6 +41,8 @@ import luci.sixsixsix.powerampache2.domain.errors.ErrorHandler
 import luci.sixsixsix.powerampache2.domain.models.Playlist
 import luci.sixsixsix.powerampache2.domain.models.PlaylistType
 import luci.sixsixsix.powerampache2.domain.models.Song
+import luci.sixsixsix.powerampache2.domain.models.USER_SYSTEM
+import luci.sixsixsix.powerampache2.domain.models.User
 import luci.sixsixsix.powerampache2.domain.usecase.UserFlowUseCase
 import luci.sixsixsix.powerampache2.domain.usecase.playlists.PlaylistsFlow
 import luci.sixsixsix.powerampache2.domain.usecase.playlists.PlaylistsUseCase
@@ -63,7 +65,7 @@ class AddToPlaylistOrQueueDialogViewModel @Inject constructor(
     val playlistsStateFlow: StateFlow<List<Playlist>> =
         playlistsFlow().filterNotNull().distinctUntilChanged()
             .combine(userFlowUseCase().filterNotNull().distinctUntilChanged()) { playlists, user ->
-                playlists.filter { it.owner?.lowercase() == user.username.lowercase() }
+                filterPlaylists(playlists, user)
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), listOf())
 
     fun onEvent(event: AddToPlaylistOrQueueDialogEvent) {
@@ -108,6 +110,22 @@ class AddToPlaylistOrQueueDialogViewModel @Inject constructor(
                         }
                     }
                 }
+        }
+    }
+
+    private fun filterPlaylists(playlists: List<Playlist>, user: User): List<Playlist> {
+        val username = user.username.lowercase()
+
+        return if (user.isAdmin()) {
+            playlists.sortedBy { playlist ->
+                when (playlist.owner?.lowercase()) {
+                    username -> 0
+                    USER_SYSTEM -> 1
+                    else -> 2
+                }
+            }
+        } else {
+            playlists.filter { it.owner?.lowercase() == username }
         }
     }
 

--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
@@ -117,7 +117,7 @@ class AddToPlaylistOrQueueDialogViewModel @Inject constructor(
         val username = user.username.lowercase()
 
         return if (user.isAdmin()) {
-            playlists.sortedBy { playlist ->
+            playlists.sortedBy { it.name }.sortedBy { playlist ->
                 when (playlist.owner?.lowercase()) {
                     username -> 0
                     USER_SYSTEM -> 1
@@ -125,7 +125,7 @@ class AddToPlaylistOrQueueDialogViewModel @Inject constructor(
                 }
             }
         } else {
-            playlists.filter { it.owner?.lowercase() == username }
+            playlists.filter { it.owner?.lowercase() == username }.sortedBy { it.name }
         }
     }
 

--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens_detail/playlist_detail/PlaylistDetailViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens_detail/playlist_detail/PlaylistDetailViewModel.kt
@@ -105,7 +105,7 @@ class PlaylistDetailViewModel @Inject constructor(
                 state = state.copy(
                     isNotStatPlaylist = PlaylistDetailState.isNotStatPlaylist(playlist),
                     isGeneratedOrSmartPlaylist = PlaylistDetailState.isGeneratedOrSmartPlaylist(playlist),
-                    isUserOwner = user.username.lowercase() == playlist.owner?.lowercase()
+                    isUserOwner = user.username.lowercase() == playlist.owner?.lowercase() || user.isAdmin()
                 )
                 playlist
             }.flatMapConcat { playlist ->

--- a/domain/src/main/java/luci/sixsixsix/powerampache2/domain/models/User.kt
+++ b/domain/src/main/java/luci/sixsixsix/powerampache2/domain/models/User.kt
@@ -35,6 +35,8 @@ import luci.sixsixsix.powerampache2.domain.common.Constants.USER_ACCESS_DEFAULT
 import luci.sixsixsix.powerampache2.domain.common.Constants.USER_DEFAULT_MASTODON_URL
 import luci.sixsixsix.powerampache2.domain.common.Constants.USER_ID_ERROR
 
+const val USER_SYSTEM = "system"
+
 @Parcelize
 data class User(
     val id: String,
@@ -63,6 +65,10 @@ data class User(
                 email.isBlank() &&
                 createDate == Constants.ERROR_INT &&
                 lastSeen == Constants.ERROR_INT
+
+    fun isAdmin(): Boolean {
+        return (access >= 100)
+    }
 
     companion object {
         fun emptyUser(): User = User(

--- a/domain/src/main/java/luci/sixsixsix/powerampache2/domain/models/User.kt
+++ b/domain/src/main/java/luci/sixsixsix/powerampache2/domain/models/User.kt
@@ -70,16 +70,14 @@ data class User(
         this.access >= level
 
     fun isAdmin() =
-        this.isAccessAtLeast(Access.ADMIN)
+        this.isAccessAtLeast(ACCESS_ADMIN)
 
     companion object {
-        object Access {
-            const val GUEST = 5
-            const val USER = 25
-            const val CONTENT_MANAGER = 50
-            const val CATALOG_MANAGER = 75
-            const val ADMIN = 100
-        }
+        const val ACCESS_GUEST = 5
+        const val ACCESS_ACCESS = 25
+        const val ACCESS_CONTENT_MANAGER = 50
+        const val ACCESS_CATALOG_MANAGER = 75
+        const val ACCESS_ADMIN = 100
 
         fun emptyUser(): User = User(
             "", "", "",

--- a/domain/src/main/java/luci/sixsixsix/powerampache2/domain/models/User.kt
+++ b/domain/src/main/java/luci/sixsixsix/powerampache2/domain/models/User.kt
@@ -35,7 +35,7 @@ import luci.sixsixsix.powerampache2.domain.common.Constants.USER_ACCESS_DEFAULT
 import luci.sixsixsix.powerampache2.domain.common.Constants.USER_DEFAULT_MASTODON_URL
 import luci.sixsixsix.powerampache2.domain.common.Constants.USER_ID_ERROR
 
-const val USER_SYSTEM = "system"
+const val USER_SYSTEM = "system"  // Name of Ampache's system user. Can own playlists.
 
 @Parcelize
 data class User(
@@ -66,11 +66,21 @@ data class User(
                 createDate == Constants.ERROR_INT &&
                 lastSeen == Constants.ERROR_INT
 
-    fun isAdmin(): Boolean {
-        return (access >= 100)
-    }
+    fun isAccessAtLeast(level: Int) =
+        this.access >= level
+
+    fun isAdmin() =
+        this.isAccessAtLeast(Access.ADMIN)
 
     companion object {
+        object Access {
+            const val GUEST = 5
+            const val USER = 25
+            const val CONTENT_MANAGER = 50
+            const val CATALOG_MANAGER = 75
+            const val ADMIN = 100
+        }
+
         fun emptyUser(): User = User(
             "", "", "",
             Constants.ERROR_INT,


### PR DESCRIPTION
Add several checks for user's access level, allowing admins to edit any existing playlist on the server, regardless of it's owner:
- Check for access when constructing a list of playlists in AddToPlaylistOrQueueDialog
- Check for access in PlaylistDetailViewModel, to allow deleting songs from PlaylistDetailScreen with swiping motion

Users with access level of 100 are considered admins, according to Ampache API.