### PR TITLE
Sort playlists alphabetically (after other sorting filters)

### DIFF
--- a/app/src/main/java/luci/sixsixsix/powerampache2/common/Extensions.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/common/Extensions.kt
@@ -62,7 +62,9 @@ import luci.sixsixsix.powerampache2.R
 import luci.sixsixsix.powerampache2.common.Constants.PLAY_STORE_URL
 import luci.sixsixsix.powerampache2.domain.common.Constants.PLUGIN_CHROMECAST_ACTIVITY_ID
 import luci.sixsixsix.powerampache2.domain.common.Constants.PLUGIN_CHROMECAST_ID
+import luci.sixsixsix.powerampache2.domain.models.Playlist
 import luci.sixsixsix.powerampache2.domain.models.Song
+import luci.sixsixsix.powerampache2.domain.models.User
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -266,4 +268,8 @@ fun Modifier.shimmer(): Modifier = composed {
     ).onGloballyPositioned {
         size = it.size
     }
+}
+
+fun Playlist.isUserOwner(user: User): Boolean {
+    return user.isAdmin() || user.username.equals(other = this.owner, ignoreCase = true)
 }

--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import luci.sixsixsix.mrlog.L
 import luci.sixsixsix.powerampache2.common.Resource
+import luci.sixsixsix.powerampache2.common.isUserOwner
 import luci.sixsixsix.powerampache2.domain.PlaylistsRepository
 import luci.sixsixsix.powerampache2.domain.errors.ErrorHandler
 import luci.sixsixsix.powerampache2.domain.models.Playlist
@@ -117,7 +118,7 @@ class AddToPlaylistOrQueueDialogViewModel @Inject constructor(
         val filteredList = mutableListOf<Playlist>()
 
         playlists.filterNot { it.isSmartPlaylist() }.forEach { playlist ->
-            if (user.isAdmin() || user.username.equals(other = playlist.owner, ignoreCase = true)) {
+            if (playlist.isUserOwner(user)) {
                 filteredList.add(playlist)
             }
         }

--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/dialogs/AddToPlaylistOrQueueDialogViewModel.kt
@@ -41,8 +41,8 @@ import luci.sixsixsix.powerampache2.domain.errors.ErrorHandler
 import luci.sixsixsix.powerampache2.domain.models.Playlist
 import luci.sixsixsix.powerampache2.domain.models.PlaylistType
 import luci.sixsixsix.powerampache2.domain.models.Song
-import luci.sixsixsix.powerampache2.domain.models.USER_SYSTEM
 import luci.sixsixsix.powerampache2.domain.models.User
+import luci.sixsixsix.powerampache2.domain.models.isSmartPlaylist
 import luci.sixsixsix.powerampache2.domain.usecase.UserFlowUseCase
 import luci.sixsixsix.powerampache2.domain.usecase.playlists.PlaylistsFlow
 import luci.sixsixsix.powerampache2.domain.usecase.playlists.PlaylistsUseCase
@@ -114,19 +114,15 @@ class AddToPlaylistOrQueueDialogViewModel @Inject constructor(
     }
 
     private fun filterPlaylists(playlists: List<Playlist>, user: User): List<Playlist> {
-        val username = user.username.lowercase()
+        val filteredList = mutableListOf<Playlist>()
 
-        return if (user.isAdmin()) {
-            playlists.sortedBy { it.name }.sortedBy { playlist ->
-                when (playlist.owner?.lowercase()) {
-                    username -> 0
-                    USER_SYSTEM -> 1
-                    else -> 2
-                }
+        playlists.filterNot { it.isSmartPlaylist() }.forEach { playlist ->
+            if (user.isAdmin() || user.username.equals(other = playlist.owner, ignoreCase = true)) {
+                filteredList.add(playlist)
             }
-        } else {
-            playlists.filter { it.owner?.lowercase() == username }.sortedBy { it.name }
         }
+
+        return filteredList
     }
 
     private fun createPlaylistAddSong(

--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens/playlists/PlaylistsViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens/playlists/PlaylistsViewModel.kt
@@ -40,6 +40,7 @@ import luci.sixsixsix.powerampache2.common.Resource
 import luci.sixsixsix.powerampache2.domain.PlaylistsRepository
 import luci.sixsixsix.powerampache2.domain.common.Constants.ALWAYS_FETCH_ALL_PLAYLISTS
 import luci.sixsixsix.powerampache2.domain.models.Playlist
+import luci.sixsixsix.powerampache2.domain.models.User
 import luci.sixsixsix.powerampache2.domain.usecase.UserFlowUseCase
 import luci.sixsixsix.powerampache2.domain.usecase.playlists.PlaylistsFlow
 import luci.sixsixsix.powerampache2.domain.usecase.playlists.PlaylistsUseCase
@@ -56,7 +57,7 @@ class PlaylistsViewModel @Inject constructor(
 ) : ViewModel() {
     var state by mutableStateOf(PlaylistsState())
     private var isEndOfDataReached: Boolean = false
-    private lateinit var currentUsername: String
+    private lateinit var currentUser: User
 
     val playlistsStateFlow: StateFlow<List<Playlist>> =
         offlineModeFlow()
@@ -64,19 +65,18 @@ class PlaylistsViewModel @Inject constructor(
             .filterNotNull()
             .distinctUntilChanged()
             .combine(userFlowUseCase().filterNotNull().distinctUntilChanged()) { playlists, user ->
-                currentUsername = user.username
+                currentUser = user
                 playlists
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), listOf())
 
     fun isCurrentUserOwner(playlist: Playlist) =
-        currentUsername.lowercase() == playlist.owner?.lowercase()
+        currentUser.username.lowercase() == playlist.owner?.lowercase() || currentUser.isAdmin()
 
     fun onEvent(event: PlaylistEvent) {
         when (event) {
             is PlaylistEvent.Refresh ->
                 getPlaylists(fetchRemote = true)
-            is PlaylistEvent.OnSearchQueryChange -> if (event.query.isBlank() && state.searchQuery.isBlank()) {
-                } else {
+            is PlaylistEvent.OnSearchQueryChange -> if (event.query.isNotBlank() || state.searchQuery.isNotBlank()) {
                     state = state.copy(searchQuery = event.query)
                     getPlaylists()
                 }

--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens/playlists/PlaylistsViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens/playlists/PlaylistsViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import luci.sixsixsix.mrlog.L
 import luci.sixsixsix.powerampache2.common.Resource
+import luci.sixsixsix.powerampache2.common.isUserOwner
 import luci.sixsixsix.powerampache2.domain.PlaylistsRepository
 import luci.sixsixsix.powerampache2.domain.common.Constants.ALWAYS_FETCH_ALL_PLAYLISTS
 import luci.sixsixsix.powerampache2.domain.models.Playlist
@@ -70,7 +71,7 @@ class PlaylistsViewModel @Inject constructor(
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), listOf())
 
     fun isCurrentUserOwner(playlist: Playlist) =
-        currentUser.username.lowercase() == playlist.owner?.lowercase() || currentUser.isAdmin()
+        playlist.isUserOwner(currentUser)
 
     fun onEvent(event: PlaylistEvent) {
         when (event) {

--- a/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens_detail/playlist_detail/PlaylistDetailViewModel.kt
+++ b/app/src/main/java/luci/sixsixsix/powerampache2/presentation/screens_detail/playlist_detail/PlaylistDetailViewModel.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.launch
 import luci.sixsixsix.mrlog.L
 import luci.sixsixsix.powerampache2.R
 import luci.sixsixsix.powerampache2.common.Resource
+import luci.sixsixsix.powerampache2.common.isUserOwner
 import luci.sixsixsix.powerampache2.common.shareLink
 import luci.sixsixsix.powerampache2.domain.PlaylistsRepository
 import luci.sixsixsix.powerampache2.domain.SongsRepository
@@ -105,7 +106,7 @@ class PlaylistDetailViewModel @Inject constructor(
                 state = state.copy(
                     isNotStatPlaylist = PlaylistDetailState.isNotStatPlaylist(playlist),
                     isGeneratedOrSmartPlaylist = PlaylistDetailState.isGeneratedOrSmartPlaylist(playlist),
-                    isUserOwner = user.username.lowercase() == playlist.owner?.lowercase() || user.isAdmin()
+                    isUserOwner = playlist.isUserOwner(user)
                 )
                 playlist
             }.flatMapConcat { playlist ->

--- a/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/MusicDao.kt
+++ b/data-ampache/src/main/java/luci/sixsixsix/powerampache2/data/local/MusicDao.kt
@@ -367,7 +367,7 @@ interface MusicDao {
     @Query("""SELECT * FROM playlistentity WHERE (LOWER(name) LIKE '%' || LOWER(:query) || '%' OR LOWER(:query) == name)
         AND $multiUserCondition
         GROUP BY id
-        ORDER BY flag DESC, rating DESC, (LOWER(owner) == LOWER( (SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY')) ) DESC, id DESC""")
+        ORDER BY flag DESC, rating DESC, (LOWER(owner) == LOWER( (SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY')) ) DESC, name""")
     suspend fun searchPlaylists(query: String): List<PlaylistEntity>
 
     @Query("""
@@ -382,7 +382,7 @@ interface MusicDao {
     ORDER BY 
         flag DESC, rating DESC,
         (LOWER(owner) == LOWER((SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY'))) DESC,
-        id DESC
+        name
     """)
     suspend fun searchOfflinePlaylists(query: String): List<PlaylistEntity>
 
@@ -397,25 +397,25 @@ interface MusicDao {
     ORDER BY 
         flag DESC, rating DESC,
         (LOWER(owner) == LOWER((SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY'))) DESC,
-        id DESC
+        name
     """)
     fun playlistsOfflineFlow(): Flow<List<PlaylistEntity>>
 
 
-    @Query("""SELECT * FROM playlistentity WHERE $multiUserCondition order by flag DESC, rating DESC, (LOWER(owner) == LOWER((SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY')) ) DESC, id DESC""")
+    @Query("""SELECT * FROM playlistentity WHERE $multiUserCondition order by flag DESC, rating DESC, (LOWER(owner) == LOWER((SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY')) ) DESC, name""")
     fun playlistsFlow(): Flow<List<PlaylistEntity>>
 
-    @Query("""SELECT * FROM playlistentity WHERE $multiUserCondition order by flag DESC, rating DESC, id DESC""")
+    @Query("""SELECT * FROM playlistentity WHERE $multiUserCondition order by flag DESC, rating DESC, name""")
     suspend fun getAllPlaylists(): List<PlaylistEntity>
 
     @Query("""SELECT * FROM playlistentity WHERE id == :playlistId AND $multiUserCondition""")
     fun playlistFlow(playlistId: String): Flow<PlaylistEntity?>
 
     // get only playlists user owns
-    @Query("""SELECT * FROM playlistentity WHERE LOWER(owner) = LOWER((SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY')) order by rating DESC, id DESC""")
+    @Query("""SELECT * FROM playlistentity WHERE LOWER(owner) = LOWER((SELECT username FROM credentialsentity WHERE primaryKey == '$CREDENTIALS_PRIMARY_KEY')) order by rating DESC, name""")
     suspend fun getMyPlaylists(): List<PlaylistEntity>
 
-    @Query("""SELECT * FROM playlistentity WHERE LOWER(owner) = LOWER('admin') order by rating DESC, id DESC""")
+    @Query("""SELECT * FROM playlistentity WHERE LOWER(owner) = LOWER('admin') order by rating DESC, name""")
     suspend fun getAdminPlaylists(): List<PlaylistEntity>
 
 // --- OFFLINE SONGS ---


### PR DESCRIPTION
Adds alphabetical sorting to SQL queries related to lists of playlists, playlist flows and search results.
This does not change the rest of existing sorting behavior, it only swaps sorting by `id` in the end to sorting by the `name`.

This means, that the sorting order for playlists screen and home screen playlist section is now as follows:
`is playlist favorited` -> `rating value (desc)` -> `is the current user owner` -> `playlist name (asc)`

In search results, list of playlists is sorted by `name` instead of `id` as well.

This PR also contains a fix for playlist viewmodel not checking if the user has admin privileges, which it now does, therefore allows admins to delete any existing playlist with a swiping motion on the playlists screen, and not just the ones created by them.